### PR TITLE
fix issue where running an action would eat exceptions

### DIFF
--- a/lib/mb/gears/service.rb
+++ b/lib/mb/gears/service.rb
@@ -125,13 +125,16 @@ module MotherBrain
         # Run this action on the specified nodes.
         #
         # @param [Array<Ridley::Node>] nodes the nodes to run this action on
+        #
+        # @return [Service::Action]
         def run(nodes)
           @nodes = nodes
           runner.instance_eval(&block)
           chef_run(nodes)
+
+          self
         ensure
           runner.reset!
-          return self
         end
 
         # Run chef on the specified nodes.

--- a/spec/unit/mb/gears/service_spec.rb
+++ b/spec/unit/mb/gears/service_spec.rb
@@ -192,10 +192,14 @@ describe MB::Gear::Service do
         ridley_object.should_receive(:set_attribute).with("some.attr", "before_val").exactly(3).times
         ridley_object.should_receive(:save).exactly(6).times
 
-        MB::Gear::Service::Action.new(@context, action_name, component) do
+        action = MB::Gear::Service::Action.new(@context, action_name, component) do
           node_attribute("some.attr", "val", toggle: true)
           this_does_not_exist!
-        end.run(nodes)
+        end
+
+        lambda {
+          action.run(nodes)
+        }.should raise_error(NoMethodError)
       end
     end
   end


### PR DESCRIPTION
@jhowarth using the `return` keyword in an ensure block will eat exceptions
