### PR TITLE
remove line logger added by previous commit

### DIFF
--- a/lib/mb/command.rb
+++ b/lib/mb/command.rb
@@ -137,8 +137,6 @@ module MotherBrain
         options[:max_concurrent] ||= nodes.count
         node_groups = nodes.each_slice(options[:max_concurrent]).to_a
 
-        MB.log.warn actions.first.run(nodes)
-
         @on_procs << lambda do
           node_groups.each do |nodes|
             actions.each do |action|


### PR DESCRIPTION
@jhowarth this is what was causing the specs to fail.

It was added in this commit by me: https://github.com/RiotGames/motherbrain/commit/c61ffdd40730c04b09a3d22afbd034867f899af5
