### PR TITLE
Prevent deadlocks when inspecting a job

### DIFF
--- a/lib/mb/job.rb
+++ b/lib/mb/job.rb
@@ -143,6 +143,11 @@ module MotherBrain
       JobManager.instance.complete_job(Actor.current)
     end
 
+    def to_s
+      "#<Job @type=#{type.inspect} @machine.state=#{state.inspect}>"
+    end
+    alias_method :inspect, :to_s
+
     private
 
       attr_reader :machine


### PR DESCRIPTION
If Job#inspect is called from another actor, the process stops. This was preventing concurrent bootstraps from working on my machine.

Introduced in 2292ea1 (first time we inspected a job)

No idea how to test for this :metal: 
