### PR TITLE
locking does not prevent 2 simultaneous start commands

### DIFF
--- a/lib/mb/chef_mutex.rb
+++ b/lib/mb/chef_mutex.rb
@@ -137,18 +137,18 @@ module MotherBrain
       attempt_unlock
     end
 
-    # Check to see if the passed in lock was created by us
-    #
-    # @param [Hash] current_lock the lock data obtained from #read
-    # @return [Boolean]
-    def our_lock?(current_lock)
-      return nil unless current_lock
-      return false unless current_lock["client_name"] == client_name
-      return false unless current_lock["process_id"] == Process.pid
-      true
-    end
-
     private
+
+      # Check to see if the passed in lock was created by us
+      #
+      # @param [Hash] current_lock the lock data obtained from #read
+      # @return [Boolean]
+      def our_lock?(current_lock)
+        return nil unless current_lock
+        return false unless current_lock["client_name"] == client_name
+        return false unless current_lock["process_id"] == Process.pid
+        true
+      end
 
       # @return [Boolean]
       def attempt_lock

--- a/spec/unit/mb/chef_mutex_spec.rb
+++ b/spec/unit/mb/chef_mutex_spec.rb
@@ -191,7 +191,12 @@ describe MB::ChefMutex do
 
   describe "#our_lock?" do
     before do
+      chef_mutex.class.class_eval { public :our_lock? }
       chef_mutex.stub(:client_name).and_return("johndoe")
+    end
+
+    after do
+      chef_mutex.class.class_eval { private :our_lock? }
     end
 
     subject(:our_lock?) { chef_mutex.our_lock?(current_lock) }


### PR DESCRIPTION
I can run 2 instances of the following at the same time:

bundle exec bin/mb bacon bacon start bacon-applewood -v -L ./mb.log

I would expect locking to prevent this.
