### PR TITLE
need to use recursive merge on attributes

### DIFF
--- a/lib/mb/plugin_invoker.rb
+++ b/lib/mb/plugin_invoker.rb
@@ -20,7 +20,7 @@ module MotherBrain
         end
 
         plugin.components.each do |component|
-          register_component MB::ComponentInvoker.fabricate(klass, component)
+          klass.register_component MB::ComponentInvoker.fabricate(klass, component)
         end
 
         klass.class_eval do


### PR DESCRIPTION
When upgrading in the upgrade/worker.rb, we'll need to do a recursive merge on the override or default attributes we want to set.  Otherwise the results could be unexpected.

For example, in bacon's orchestrator we do this:
https://gh.riotgames.com/bacon/bacon-orchestrator/blob/master/lib/chef_util.rb#L188
