### PR TITLE
Plugins don't keep tasks segregated

### DIFF
--- a/lib/mb/plugin_invoker.rb
+++ b/lib/mb/plugin_invoker.rb
@@ -20,7 +20,7 @@ module MotherBrain
         end
 
         plugin.components.each do |component|
-          register_component MB::ComponentInvoker.fabricate(klass, component)
+          klass.register_component MB::ComponentInvoker.fabricate(klass, component)
         end
 
         klass.class_eval do


### PR DESCRIPTION
I have 2 plugins. If I run `mb plugins` I see both, but if I run `mb second` I see the commands and tasks associated with the first plugin.
