### PR TITLE
Pass the logging path as a string to be compatible with jruby's #open

### DIFF
--- a/lib/mb/logging.rb
+++ b/lib/mb/logging.rb
@@ -46,7 +46,7 @@ module MotherBrain
           setup_logdir(location)
         end
 
-        @logger = Logger.new(location).tap do |log|
+        @logger = Logger.new(location.to_s).tap do |log|
           log.level = level
           log.formatter = BasicFormat.new
         end


### PR DESCRIPTION
I encountered this issue via the following command running under jruby 1.7.0

plugin:

``` ruby
command "disable" do
  execute do
    on("team_server", any: 1) do
      jmx.run(9001, "com.riotgames.platform.management:group=TeamManagement,name=TeamPropertiesManager") do |mbean|
        mbean.setTeamServiceEnabled(false)
      end
    end
  end
end
```

error output:

```
rapier:Projects jkiehl$ mb riot_team team_server disable jh0
TypeError: can't convert Pathname into String
            open at org/jruby/RubyKernel.java:319
  create_logfile at /Users/jkiehl/.rbenv/versions/jruby-1.7.0/lib/ruby/1.9/logger.rb:599
    open_logfile at /Users/jkiehl/.rbenv/versions/jruby-1.7.0/lib/ruby/1.9/logger.rb:594
      initialize at /Users/jkiehl/.rbenv/versions/jruby-1.7.0/lib/ruby/1.9/logger.rb:549
      initialize at /Users/jkiehl/.rbenv/versions/jruby-1.7.0/lib/ruby/1.9/logger.rb:314
      initialize at /Users/jkiehl/.rbenv/versions/jruby-1.7.0/lib/ruby/gems/shared/gems/activesupport-3.2.11/lib/active_support/core_ext/logger.rb:72
           setup at /Users/jkiehl/.rbenv/versions/jruby-1.7.0/lib/ruby/gems/shared/gems/motherbrain-0.0.1/lib/mb/logging.rb:49
       configure at /Users/jkiehl/.rbenv/versions/jruby-1.7.0/lib/ruby/gems/shared/gems/motherbrain-0.0.1/lib/mb/invoker_base.rb:25
           start at /Users/jkiehl/.rbenv/versions/jruby-1.7.0/lib/ruby/gems/shared/gems/motherbrain-0.0.1/lib/mb/invoker.rb:9
          (root) at /Users/jkiehl/.rbenv/versions/jruby-1.7.0/lib/ruby/gems/shared/gems/motherbrain-0.0.1/bin/mb:6
            load at org/jruby/RubyKernel.java:1045
          (root) at /Users/jkiehl/.rbenv/versions/jruby-1.7.0/bin/mb:23
```
