### PR TITLE
Dependency "yajl-ruby" is not defined in the gemspec.

### DIFF
--- a/motherbrain.gemspec
+++ b/motherbrain.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'faraday'
   s.add_runtime_dependency 'ef-rest'
   s.add_runtime_dependency 'activesupport'
+  s.add_runtime_dependency 'yajl-ruby'
 end


### PR DESCRIPTION
I get require errors when I try to run a freshly built mb.
