### PR TITLE
plugin commands should use the correct plugin version

### DIFF
--- a/lib/mb/invoker.rb
+++ b/lib/mb/invoker.rb
@@ -33,6 +33,7 @@ module MotherBrain
           cookbook_identifier = "#{name}"
           cookbook_identifier += " (version #{version})" if version
           MB.ui.say "No cookbook with #{cookbook_identifier} plugin was found in your Berkshelf."
+          exit 1
         end
       end
 

--- a/spec/unit/mb/invoker_spec.rb
+++ b/spec/unit/mb/invoker_spec.rb
@@ -24,7 +24,9 @@ describe MB::Invoker do
 
           it "should notify the user" do
             MB.ui.should_receive(:say).with("No cookbook with myface (version 1.2.3) plugin was found in your Berkshelf.")
-            subject.register_plugin name, version
+            lambda {
+              subject.register_plugin name, version
+            }.should raise_error(SystemExit)
           end
         end
 
@@ -50,7 +52,9 @@ describe MB::Invoker do
 
           it "should notify the user" do
             MB.ui.should_receive(:say).with("No cookbook with myface plugin was found in your Berkshelf.")
-            subject.register_plugin name, version
+            lambda {
+              subject.register_plugin name, version
+            }.should raise_error(SystemExit)
           end
         end
 


### PR DESCRIPTION
Which plugin to use needs to be determined before executing a command.

We can do so by checking the cookbook version that is locked to the environment and downloading/using that plugin version.

This means most, if not all, commands will have to take an environment as a parameter.
