### PR TITLE
cli does not output correct error codes

### DIFF
--- a/lib/mb/cli_client.rb
+++ b/lib/mb/cli_client.rb
@@ -64,7 +64,7 @@ module MotherBrain
       end
 
       def jobs_failed?
-        jobs.any?(&:failure?)
+        jobs.any?(&:failed?)
       end
 
       # @param [MotherBrain::Job] job

--- a/lib/mb/job/states.rb
+++ b/lib/mb/job/states.rb
@@ -21,6 +21,7 @@ module MotherBrain
       def failure?
         self.state == :failure
       end
+      alias_method :failed?, :failure?
 
       # If a job has not begun and is in the pending state it is considered pending
       #


### PR DESCRIPTION
The CLI is exiting with 0 even on failures.

See: https://gh.riotgames.com/gist/740
