### PR TITLE
remote loading of plugins will continue even if there is a failure

### DIFF
--- a/lib/mb/plugin_manager.rb
+++ b/lib/mb/plugin_manager.rb
@@ -331,11 +331,13 @@ module MotherBrain
           versions.each do |version|
             next if find(name, version)
 
-            load_remote(name, version)
+            begin
+              load_remote(name, version)
+            rescue PluginSyntaxError, PluginLoadError, PluginDownloadError => ex
+              log.warn { "error loading remote plugin: #{ex}" }
+            end
           end
         end
-      rescue PluginSyntaxError, PluginLoadError, PluginDownloadError => ex
-        log.warn { "error loading remote plugin: #{ex}" }
       end
   end
 end


### PR DESCRIPTION
until no potential remote plugins are left

@ivey 
