### PR TITLE
add async_loading configurable option to Plugin Manager

### DIFF
--- a/lib/mb/cli_gateway.rb
+++ b/lib/mb/cli_gateway.rb
@@ -32,6 +32,7 @@ module MotherBrain
 
         config.rest_gateway.enable = false
         config.plugin_manager.eager_loading = false
+        config.plugin_manager.async_loading = false
         config
       end
 

--- a/lib/mb/config.rb
+++ b/lib/mb/config.rb
@@ -148,6 +148,11 @@ module MotherBrain
       default: 300, # 5 minutes
       type: Integer
 
+    # Allows the plugin manager load it's plugins asynchronously in the background during startup
+    attribute 'plugin_manager.async_loading',
+      default: true,
+      type: Boolean
+
     attribute 'ef.api_url',
       type: String
 

--- a/lib/mb/plugin_manager.rb
+++ b/lib/mb/plugin_manager.rb
@@ -30,7 +30,8 @@ module MotherBrain
       @plugins        = Set.new
 
       MB::Berkshelf.init
-      load_all
+
+      async_loading? ? async(:load_all) : load_all
 
       if eager_loading?
         @eager_load_timer = every(eager_load_interval, &method(:load_all_remote))
@@ -59,6 +60,16 @@ module MotherBrain
 
       @plugins.add(plugin)
       plugin
+    end
+
+    # Should the plugin manager perform plugin loading operations in the background?
+    #
+    # @note should be disabled if running motherbrain from the CLIGateway to ensure
+    #   all plugins are loaded before being accessed
+    #
+    # @return [Boolean]
+    def async_loading?
+      Application.config.plugin_manager.async_loading
     end
 
     # Clear list of known plugins

--- a/spec/unit/mb/plugin_manager_spec.rb
+++ b/spec/unit/mb/plugin_manager_spec.rb
@@ -203,6 +203,28 @@ describe MotherBrain::PluginManager do
     end
   end
 
+  describe "#async_loading?" do
+    context "if the plugin manager is configured for async loading" do
+      before(:each) do
+        MB::Application.config.plugin_manager.stub(:async_loading) { true }
+      end
+
+      it "returns true" do
+        subject.async_loading?.should be_true
+      end
+    end
+
+    context "if the plugin manager is not configured for async loading" do
+      before(:each) do
+        MB::Application.config.plugin_manager.stub(:async_loading) { false }
+      end
+
+      it "returns false" do
+        subject.async_loading?.should be_false
+      end
+    end
+  end
+
   describe "#find" do
     let(:one) do
       metadata = MB::CookbookMetadata.new do


### PR DESCRIPTION
this is disabled in the CLIGateway
this is enabled by default
this allows the plugin manager to start and not block the rest of the startup process
