### PR TITLE
Force incoming REST requests to be Content-Type: application/json

### DIFF
--- a/lib/mb/api.rb
+++ b/lib/mb/api.rb
@@ -296,6 +296,12 @@ module MotherBrain
       end
     end
 
+    # Force inbound requests to be JSON
+    def call(env)
+      env['CONTENT_TYPE'] = 'application/json'
+      super
+    end
+
     if MB.testing?
       get :mb_error do
         raise MB::InternalError, "a nice error message"

--- a/spec/unit/mb/rest_gateway_spec.rb
+++ b/spec/unit/mb/rest_gateway_spec.rb
@@ -65,11 +65,11 @@ describe MB::RestGateway do
         plugin_manager.should_receive(:find).with(plugin_id, plugin_version).and_return(plugin)
         upgrade_manager.should_receive(:upgrade).with(environment_id, plugin, anything).and_return(job)
 
-        post "/environments/#{environment_id}/upgrade", plugin: {
-            name: plugin_id,
-            version: plugin_version
-          }
-
+        post "/environments/#{environment_id}/upgrade",
+          MultiJson.dump(plugin: {
+                           name: plugin_id,
+                           version: plugin_version
+                         })
         last_response.status.should == 201
       end
     end


### PR DESCRIPTION
Otherwise, Grape won't parse the body
