### PR TITLE
fix Celluloid#finalize deprecation warnings

### DIFF
--- a/lib/mb/api_client.rb
+++ b/lib/mb/api_client.rb
@@ -35,6 +35,10 @@ module MotherBrain
     resource ApiClient::JobResource, :job
     resource ApiClient::PluginResource, :plugin
 
+    finalizer do
+      connection.terminate if connection.alive?
+    end
+
     # @param [String] url
     #   URL to REST Gateway
     #
@@ -48,10 +52,6 @@ module MotherBrain
     def initialize(url = DEFAULT_URL, options = {})
       super(Celluloid::Registry.new)
       pool(ApiClient::Connection, size: 4, args: [url, options], as: :connection_pool)
-    end
-
-    def finalize
-      connection.terminate if connection.alive?
     end
 
     def connection

--- a/lib/mb/bootstrap/manager.rb
+++ b/lib/mb/bootstrap/manager.rb
@@ -16,6 +16,10 @@ module MotherBrain
       include MB::Mixin::Locks
       include MB::Mixin::AttributeSetting
 
+      finalizer do
+        log.info { "Bootstrap Manager stopping..." }
+      end
+
       def initialize
         log.info { "Bootstrap Manager starting..." }
       end
@@ -157,10 +161,6 @@ module MotherBrain
         job.report_failure(error)
       ensure
         job.terminate if job && job.alive?
-      end
-
-      def finalize
-        log.info { "Bootstrap Manager stopping..." }
       end
 
       private

--- a/lib/mb/config_manager.rb
+++ b/lib/mb/config_manager.rb
@@ -19,6 +19,10 @@ module MotherBrain
     # @return [MB::Config]
     attr_reader :config
 
+    finalizer do
+      log.info { "Config Manager stopping..." }
+    end
+
     # @param [MB::Config] new_config
     def initialize(new_config)
       log.info { "Config Manager starting..." }
@@ -54,10 +58,6 @@ module MotherBrain
     # @return [Boolean]
     def reloading?
       @reloading
-    end
-
-    def finalize
-      log.info { "Config Manager stopping..." }
     end
 
     private

--- a/lib/mb/environment_manager.rb
+++ b/lib/mb/environment_manager.rb
@@ -15,6 +15,10 @@ module MotherBrain
     include MB::Mixin::Locks
     include MB::Mixin::Services
 
+    finalizer do
+      log.info { "Environment Manager stopping..." }
+    end
+
     def initialize
       log.info { "Environment Manager starting..." }
     end
@@ -45,10 +49,6 @@ module MotherBrain
       async(:_configure_, environment, job, options)
 
       job.ticket
-    end
-
-    def finalize
-      log.info { "Environment Manager stopping..." }
     end
 
     # Find an environment on the remote Chef server

--- a/lib/mb/job.rb
+++ b/lib/mb/job.rb
@@ -57,6 +57,11 @@ module MotherBrain
 
     def_delegator :machine, :state
 
+    finalizer do
+      status = "complete"
+      JobManager.instance.complete_job(Actor.current)
+    end
+
     # @param [#to_s] type
     def initialize(type)
       @machine = StateMachine.new
@@ -157,11 +162,6 @@ module MotherBrain
       @result = result
       machine.transition(state, options)
       Actor.current
-    end
-
-    def finalize
-      status = "complete"
-      JobManager.instance.complete_job(Actor.current)
     end
 
     def to_s

--- a/lib/mb/job_manager.rb
+++ b/lib/mb/job_manager.rb
@@ -29,6 +29,10 @@ module MotherBrain
     attr_reader :records
     alias_method :list, :records
 
+    finalizer do
+      @_active.map { |job| job.terminate if job.alive? }
+    end
+
     def initialize
       @records = Set.new
       @_active  = Set.new
@@ -78,10 +82,6 @@ module MotherBrain
     # @return [String]
     def uuid
       Celluloid::UUID.generate
-    end
-
-    def finalize
-      @_active.map { |job| job.terminate if job.alive? }
     end
 
     private

--- a/lib/mb/lock_manager.rb
+++ b/lib/mb/lock_manager.rb
@@ -18,6 +18,10 @@ module MotherBrain
     # @return [Set<ChefMutex>]
     attr_reader :locks
 
+    finalizer do
+      log.info { "Lock Manager stopping..." }
+    end
+
     def initialize
       log.info { "Lock Manager starting..." }
       @locks = Set.new
@@ -53,10 +57,6 @@ module MotherBrain
     # @param [ChefMutex] mutex
     def unregister(mutex)
       locks.delete(mutex)
-    end
-
-    def finalize
-      log.info { "Lock Manager stopping..." }
     end
 
     # Lock an environment

--- a/lib/mb/node_querier.rb
+++ b/lib/mb/node_querier.rb
@@ -18,6 +18,10 @@ module MotherBrain
 
     EMBEDDED_RUBY_PATH = "/opt/chef/embedded/bin/ruby".freeze
 
+    finalizer do
+      log.info { "Node Querier stopping..." }
+    end
+
     def initialize
       log.info { "Node Querier starting..." }
     end
@@ -229,10 +233,6 @@ module MotherBrain
       end
 
       copy_file(options[:secret], '/etc/chef/encrypted_data_bag_secret', host, options)
-    end
-
-    def finalize
-      log.info { "Node Querier stopping..." }
     end
   end
 end

--- a/lib/mb/plugin_manager.rb
+++ b/lib/mb/plugin_manager.rb
@@ -24,6 +24,10 @@ module MotherBrain
     # @return [Timers::Timer, nil]
     attr_reader :eager_load_timer
 
+    finalizer do
+      log.info { "Plugin Manager stopping..." }
+    end
+
     def initialize
       log.info { "Plugin Manager starting..." }
       @berkshelf_path = MB::Berkshelf.path
@@ -96,10 +100,6 @@ module MotherBrain
     # @return [Integer]
     def eager_load_interval
       Application.config.plugin_manager.eager_load_interval
-    end
-
-    def finalize
-      log.info { "Plugin Manager stopping..." }
     end
 
     # Find and return a registered plugin of the given name and version. If no version

--- a/lib/mb/provisioner/manager.rb
+++ b/lib/mb/provisioner/manager.rb
@@ -52,6 +52,10 @@ module MotherBrain
       include MB::Logging
       include MB::Mixin::Services
 
+      finalizer do
+        log.info { "Provision Manager stopping..." }
+      end
+
       def initialize
         log.info { "Provision Manager starting..." }
       end
@@ -96,10 +100,6 @@ module MotherBrain
         provisioner.async.down(job, environment.to_s)
 
         ticket
-      end
-
-      def finalize
-        log.info { "Provision Manager stopping..." }
       end
 
       # Create a new environment

--- a/lib/mb/rest_gateway.rb
+++ b/lib/mb/rest_gateway.rb
@@ -28,6 +28,10 @@ module MotherBrain
 
     def_delegator :handler, :rack_app
 
+    finalizer do
+      log.info { "REST Gateway stopping..." }
+    end
+
     # @option options [String] :host ('0.0.0.0')
     # @option options [Integer] :port (1984)
     # @option options [Boolean] :quiet (false)
@@ -46,10 +50,6 @@ module MotherBrain
     # @param [Reel::Connection] connection
     def on_connect(connection)
       pool.handle(connection.detach)
-    end
-
-    def finalize
-      log.info { "REST Gateway stopping..." }
     end
 
     private


### PR DESCRIPTION
Celluloid 0.13.0 added a new way to define finalizers. It looks like this:

``` ruby
class Whatever
  include Celluloid

  finalizer do
   #do something here
  end
end
```
