### PR TITLE
recipes added to all nodes on provision

### DIFF
--- a/lib/mb/provisioner.rb
+++ b/lib/mb/provisioner.rb
@@ -38,10 +38,37 @@ module MotherBrain
       end
     end
 
+    # Request a provisioner to generate a set of nodes described by the given manifest
+    #
+    # @param [String] environment
+    #   name of the set of nodes to be created
+    # @param [MB::Provisioner::Manifest] manifest
+    #   manifest describing how many and what kind of nodes to create
+    #
+    # @example
+    #   [
+    #     {
+    #       instance_type: "m1.large",
+    #       public_hostname: "cloud-1.riotgames.com"
+    #     },
+    #     {
+    #       instance_type: "m1.small",
+    #       public_hostname: "cloud-2.riotgames.com"
+    #     }
+    #   ]
+    #
+    # @return [Array]
+    #   an array of hashes representing nodes generated of given sizes
     def up(environment, manifest)
       raise AbstractFunction
     end
 
+    # Destroy a set of provisioned nodes
+    #
+    # @param [String] environment
+    #   name of the set of nodes to destroy
+    #
+    # @return [Boolean]
     def down(environment)
       raise AbstractFunction
     end


### PR DESCRIPTION
I provisioned an environment in EF and instead of giving me 2 service nodes and 1 database node, it gave me 3 nodes that were both service and database nodes.

Using 18f1a4eb793b84d3bd5a81a188917a4407597879

https://gh.riotgames.com/gist/838
