### PR TITLE
exit CLI with a non-zero exit code on all failures

### DIFF
--- a/bin/mb
+++ b/bin/mb
@@ -2,15 +2,4 @@
 $:.push File.expand_path("../../lib", __FILE__)
 require 'motherbrain'
 
-begin
-  MB::CliGateway.start
-rescue MB::InvalidConfig => e
-  MB.ui.say e.message, :red
-  exit e.status_code
-rescue MB::MBError => e
-  MB.ui.say e, :red
-  exit e.status_code
-rescue Chozo::Errors::ChozoError => e
-  MB.ui.say e, :red
-  exit 1
-end
+MB::CliGateway.start


### PR DESCRIPTION
@jhowarth this should solve problems when named options don't pass validation
