### PR TITLE
MotherBrain::Application::SupervisionGroup crashes

### DIFF
--- a/lib/mb/cli_gateway.rb
+++ b/lib/mb/cli_gateway.rb
@@ -75,6 +75,8 @@ module MotherBrain
         # mean that if the pipe is closed, further unnecessary
         # computation will not occur.
         exit(0)
+      ensure
+        MB::Application.instance.terminate
       end
 
       # Did the user call a plugin task?


### PR DESCRIPTION
I ran a destroy command, and it appears to have destroyed the environment, but the supervision group crashed.

https://gh.riotgames.com/gist/839
