### PR TITLE
hostkey mismatch on encrypted key upload

### DIFF
--- a/lib/mb/node_querier.rb
+++ b/lib/mb/node_querier.rb
@@ -84,7 +84,8 @@ module MotherBrain
     #
     # @raise [RemoteFileCopyError]
     def copy_file(local_file, remote_file, host, options = {})
-      options = options.reverse_merge(Application.config[:ssh].to_hash)
+      options            = options.reverse_merge(Application.config[:ssh].to_hash)
+      options[:paranoid] = false
 
       log.info { "Copying file '#{local_file}' to '#{host}:#{remote_file}'" }
 


### PR DESCRIPTION
After the sftp changes I am getting host key mismatches when it tries to upload the encrypted_data_bag_secret.

Log:
https://gh.riotgames.com/gist/916
