### PR TITLE
Output log location on failure

### DIFF
--- a/lib/mb/cli_client.rb
+++ b/lib/mb/cli_client.rb
@@ -30,7 +30,7 @@ module MotherBrain
       end
 
       if jobs_failed?
-        display_log_info
+        display_log_info if log_location
         abort
       end
     end
@@ -51,7 +51,6 @@ module MotherBrain
       end
 
       def display_log_info
-        return unless log_location
         puts "#{left_space} [motherbrain] Log written to #{log_location}"
       end
 


### PR DESCRIPTION
```
  [bootstrap] searching for environment
  [bootstrap] Locking chef_environment:motherbrain_tutorial
  [bootstrap] performing bootstrap on group(s): ["app::web"]
  [bootstrap] Unlocking chef_environment:motherbrain_tutorial
  [bootstrap] Failure: there were failures while bootstrapping some groups: ["app::web"] (1 errors)
  [motherbrain] Log written to /Users/Justin/.mb/logs/application.log

```
