### PR TITLE
motherbrain should read chef config from knife.rb

### DIFF
--- a/lib/mb/plugin_manager.rb
+++ b/lib/mb/plugin_manager.rb
@@ -283,12 +283,15 @@ module MotherBrain
     #
     # @return [Array<String>]
     def local_versions(name)
-      Berkshelf.cookbooks(with_plugin: true).collect do |path|
+      local_versions = Berkshelf.cookbooks(with_plugin: true).collect do |path|
+        log.info { "looking in #{path} for plugins"}
         plugin = load_local(path)
         next if plugin.nil?
 
         plugin.name == name ? plugin.version.to_s : nil
       end.compact
+      local_versions << load_local_plugin.version.to_s if local_plugin?
+      local_versions
     end
 
     # A set of all the registered plugins
@@ -402,7 +405,7 @@ module MotherBrain
       if all_versions.empty?
         abort PluginNotFound.new(name)
       end
-
+      
       all_versions
     end
 

--- a/spec/unit/mb/plugin_manager_spec.rb
+++ b/spec/unit/mb/plugin_manager_spec.rb
@@ -454,10 +454,32 @@ describe MotherBrain::PluginManager do
     before { MB::Berkshelf.stub(cookbooks_path: fixtures_path) }
 
     context "when the local cache has at least one cookbook containing a plugin of the given name" do
+
       it "returns an array containing a string for each" do
         versions = subject.local_versions("myface")
-
         versions.should have(1).item
+        versions.should each be_a(String)
+      end
+    end
+
+    context "when there is a plugin found by local_plugin?" do
+      let(:version) { "2.0.0" }
+      let(:plugin) { double('plugin', version: version)}
+
+      before(:each) do
+        subject.stub(:load_local_plugin).and_return(plugin)
+        subject.stub(:local_plugin?).and_return(true)
+      end
+      
+      it "returns an array containing the version of the local plugin" do
+        versions = subject.local_versions("my_local_plugin")
+        versions.should have(1).item
+        versions.should each be_a(String)
+      end
+
+      it "returns an array containing all the versions of the local plugin" do
+        versions = subject.local_versions("myface")
+        versions.should have(2).items
         versions.should each be_a(String)
       end
     end


### PR DESCRIPTION
Instead of having people configure chef, motherbrain, and berkshelf, if we pointed motherbrain and berkshelf at chef's configuration then we could just teach them out to configure chef.
