### PR TITLE
Adds a confirmation step before destroying environments

### DIFF
--- a/lib/mb/cli_gateway.rb
+++ b/lib/mb/cli_gateway.rb
@@ -412,13 +412,13 @@ module MotherBrain
       destroy_options = Hash.new.merge(options).deep_symbolize_keys
 
       dialog = "This will destroy the '#{options[:environment]}' environment.\nAre you sure? (yes|no): "
-      really_destroy = options[:yes] || MB.ui.yes?(dialog)
+      really_destroy = options[:yes] || ui.yes?(dialog)
 
       if really_destroy
         job = provisioner.async_destroy(options[:environment], destroy_options)
         CliClient.new(job).display
       else
-        MB.ui.say("Aborting destruction of '#{options[:environment]}'")
+        ui.say("Aborting destruction of '#{options[:environment]}'")
       end
     end
 


### PR DESCRIPTION
Also adds --yes/-y command line option to skip the confirmation for usage in scripts
