### PR TITLE
lock to Celluloid-IO 0.13.0 because 0.13.1 has a segfault issue

### DIFF
--- a/motherbrain.gemspec
+++ b/motherbrain.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9.3"
 
   s.add_runtime_dependency 'celluloid', '~> 0.13.0'
+  s.add_runtime_dependency 'celluloid-io', '= 0.13.0'
   s.add_runtime_dependency 'dcell', '~> 0.13.0'
   s.add_runtime_dependency 'reel', '>= 0.3.0'
   s.add_runtime_dependency 'grape', '>= 0.3.2'


### PR DESCRIPTION
@halorgium says this is already fixed and will be released soon

Here is a [link to the segfault](https://gist.github.com/reset/5485557)
