### PR TITLE
motherbrain console

### DIFF
--- a/lib/mb/cli_gateway.rb
+++ b/lib/mb/cli_gateway.rb
@@ -320,6 +320,12 @@ module MotherBrain
       MB.ui.say "Config written to: '#{path}'"
     end
 
+    desc "console", "Start an interactive motherbrain console"
+    def console
+      require 'mb/console'
+      MB::Console.start
+    end
+
     desc "version", "Display version and license information"
     def version
       MB.ui.say version_header

--- a/lib/mb/console.rb
+++ b/lib/mb/console.rb
@@ -1,0 +1,36 @@
+require 'pry'
+require 'pry/repl'
+
+module MotherBrain
+  # @author Jamie Winsor <reset@riotgames.com>
+  class Console < Pry::REPL
+    class << self
+      # @option options [Object] :target ({MB::Application})
+      #   The initial context for this session.
+      # @option options [Array<Proc>] :prompt ({Console.default_prompt})
+      #   The array of Procs to use for prompts.
+      # @option options [#readline] :input
+      #   The object to use for input.
+      # @option options [#puts] :output
+      #   The object to use for output.
+      # @option options [Pry::CommandBase] :commands
+      #   The object to use for commands.
+      # @option options [Hash] :hooks
+      #   The defined hook Procs.
+      # @option options [Proc] :print
+      #   The Proc to use for printing return values.
+      # @option options [Boolean] :quiet
+      #   Omit the `whereami` banner when starting.
+      # @option options [Array<String>] :backtrace
+      #   The backtrace of the session's `binding.pry` line, if applicable.
+      def start(options = {})
+        options = options.reverse_merge(target: MB::Application, prompt: method(:default_prompt))
+        super(options)
+      end
+
+      def default_prompt(target, nest_level, pry)
+        "mb(#{Pry.view_clip(target.class)}: #{Pry.view_clip(target)}):[#{nest_level}] >> "
+      end
+    end
+  end
+end

--- a/motherbrain.gemspec
+++ b/motherbrain.gemspec
@@ -52,4 +52,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'multi_json'
   s.add_runtime_dependency 'fog', '~> 1.10.0'
   s.add_runtime_dependency 'json', '>= 1.8.0'
+  s.add_runtime_dependency 'pry', '= 1.0.0.pre1'
 end


### PR DESCRIPTION
Adds 'mb console' command to allow easy REPL testing with a pre-started motherbrain application
