### PR TITLE
Revert "Do not allow writing to std{err,out}"

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,13 +37,6 @@ def setup_rspec
     config.before(:each) do
       clean_tmp_path
     end
-
-    config.around do |example|
-      $stdout.should_not_receive :write
-      $stderr.should_not_receive :write
-
-      example.run
-    end
   end
 end
 


### PR DESCRIPTION
This reverts commit 412d5738f73997f0769747bb7f72f54b5c88db2e.

Setting a should not expectation to stderr and stdout was causing tests to fail for a confusing reason until I checked to see if this expectation was added somewhere in the spec_helper or support files.

Was this done to prevent tests from outputting anything or to guard against something else?

I often write to stdout while I'm testing things instead of using pry just for simplicities sake.

@justincampbell
