### PR TITLE
"local" plugins is an overloaded term. Use "local" and "installed" instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ server by running `mb plugin list --remote`:
 ```
 $ mb plugin list --remote
 
-** listing local and remote plugins...
+** listing installed and remote plugins...
 
 ```
 

--- a/features/cli/plugin_command/list_command.feature
+++ b/features/cli/plugin_command/list_command.feature
@@ -15,7 +15,7 @@ Feature: listing the plugins available to motherbrain
     Then the output should contain:
       """
 
-      ** listing local plugins...
+      ** listing installed plugins...
 
       pvpnet: 1.2.3, 2.3.4
       league: 1.0.0

--- a/lib/mb/cli_gateway.rb
+++ b/lib/mb/cli_gateway.rb
@@ -72,7 +72,7 @@ module MotherBrain
           plugin
         elsif local_plugin?
           ui.info "Loading #{name} plugin from: #{Dir.pwd}"
-          plugin_manager.load_local(Dir.pwd, allow_failure: false)
+          plugin_manager.load_installed(Dir.pwd, allow_failure: false)
         elsif options[:environment]
           plugin = begin
             ui.info "Determining best version of the #{name} plugin to use with the #{options[:environment]}" +

--- a/lib/mb/cli_gateway/sub_commands/plugin.rb
+++ b/lib/mb/cli_gateway/sub_commands/plugin.rb
@@ -54,11 +54,11 @@ module MotherBrain
         def list
           if options[:remote]
             ui.say "\n"
-            ui.say "** listing local and remote plugins..."
+            ui.say "** listing installed and remote plugins..."
             ui.say "\n"
           else
             ui.say "\n"
-            ui.say "** listing local plugins...\n"
+            ui.say "** listing installed plugins...\n"
             ui.say "\n"
           end
 

--- a/spec/unit/mb/cli_gateway_spec.rb
+++ b/spec/unit/mb/cli_gateway_spec.rb
@@ -238,14 +238,14 @@ describe MB::CliGateway do
         before { described_class.stub(local_plugin?: true) }
 
         it "should prefer the local plugin if no version was specified" do
-          plugin_manager.should_receive(:load_local).and_return(plugin)
+          plugin_manager.should_receive(:load_installed).and_return(plugin)
 
           subject.should eql(plugin)
         end
 
         it "should use the version specified version of the plugin if a version is specified" do
           options[:plugin_version] = '1.2.3'
-          plugin_manager.should_not_receive(:load_local)
+          plugin_manager.should_not_receive(:load_installed)
           plugin_manager.should_receive(:find).with('myface', '1.2.3', remote: true).and_return(plugin)
 
           subject.should eql(plugin)
@@ -253,7 +253,7 @@ describe MB::CliGateway do
 
         it "should use the local version if the environment is specified" do
           options[:environment] = "abc"
-          plugin_manager.should_receive(:load_local).and_return(plugin)
+          plugin_manager.should_receive(:load_installed).and_return(plugin)
 
           subject.should eql(plugin)
         end

--- a/spec/unit/mb/plugin_manager_spec.rb
+++ b/spec/unit/mb/plugin_manager_spec.rb
@@ -162,7 +162,7 @@ describe MotherBrain::PluginManager do
     end
 
     it "sends a load message to self with each plugin found in the berkshelf" do
-      subject.should_receive(:load_local).with(anything, force: false).exactly(count).times
+      subject.should_receive(:load_installed).with(anything, force: false).exactly(count).times
 
       subject.load_all
     end
@@ -186,7 +186,7 @@ describe MotherBrain::PluginManager do
     end
   end
 
-  describe "#load_local" do
+  describe "#load_installed" do
     let(:plugin) do
       metadata = MB::CookbookMetadata.new do
         name 'apple'
@@ -202,7 +202,7 @@ describe MotherBrain::PluginManager do
     end
 
     it "adds an instantiated plugin to the hash of plugins" do
-      subject.load_local(path)
+      subject.load_installed(path)
 
       subject.list.should include(plugin)
     end
@@ -529,20 +529,20 @@ describe MotherBrain::PluginManager do
     end
   end
 
-  describe "#local_versions" do
+  describe "#installed_versions" do
     before { MB::Berkshelf.stub(cookbooks_path: fixtures_path) }
 
-    context "when the local cache has at least one cookbook containing a plugin of the given name" do
+    context "when the installed cookbooks have at least one version containing a plugin" do
       it "returns an array containing a string for each" do
-        versions = subject.local_versions("myface")
+        versions = subject.installed_versions("myface")
         versions.should have(1).item
         versions.should each be_a(String)
       end
     end
 
-    context "when the local cache does not have a cookbook containing a plugin of the given name" do
+    context "when the installed cookbooks does not have a version containing a plugin" do
       it "returns an empty array" do
-        subject.local_versions("nginx").should be_empty
+        subject.installed_versions("nginx").should be_empty
       end
     end
   end
@@ -610,37 +610,37 @@ describe MotherBrain::PluginManager do
 
   describe "#versions" do
     let(:name) { "nginx" }
-    let(:local_versions) { [ "1.2.3", "2.0.0" ] }
+    let(:installed_versions) { [ "1.2.3", "2.0.0" ] }
     let(:remote_versions) { [ "3.0.0" ] }
 
     context "when given 'false' for the remote argument" do
       before do
         subject.should_not_receive(:remote_versions)
-        subject.should_receive(:local_versions).with(name).and_return(local_versions)
+        subject.should_receive(:installed_versions).with(name).and_return(installed_versions)
       end
 
-      it "returns only the local plugins" do
-        expect(subject.versions(name, false)).to eql(local_versions)
+      it "returns only the installed plugins" do
+        expect(subject.versions(name, false)).to eql(installed_versions)
       end
     end
 
     context "when given 'true' for the remote argument" do
       before do
         subject.should_receive(:remote_versions).with(name).and_return(remote_versions)
-        subject.should_receive(:local_versions).with(name).and_return(local_versions)
+        subject.should_receive(:installed_versions).with(name).and_return(installed_versions)
       end
 
       it "includes the remote versions" do
         expect(subject.versions(name, true)).to include(*remote_versions)
       end
 
-      it "includes the local versions" do
-        expect(subject.versions(name, true)).to include(*local_versions)
+      it "includes the installed versions" do
+        expect(subject.versions(name, true)).to include(*installed_versions)
       end
 
       context "when no plugins are found" do
         let(:remote_versions) { Array.new }
-        let(:local_versions) { Array.new }
+        let(:installed_versions) { Array.new }
 
         it "raises a PluginNotFound error" do
           expect { subject.versions(name, true) }.to raise_error(MB::PluginNotFound)


### PR DESCRIPTION
- Local Plugin: this should be a plugin found within the current working directory
- Installed Plugin: this should be a plugin found within a cookbook installed in your Berkshelf

We should refactor the `PluginManager` and anywhere else to ensure that we don't overload the term "local plugin".
