### PR TITLE
ChefMutex#synchronize should not raise and crash the mutex

### DIFF
--- a/lib/mb/chef_mutex.rb
+++ b/lib/mb/chef_mutex.rb
@@ -138,7 +138,7 @@ module MotherBrain
         unlock if unlock_on_failure
       end
 
-      raise(ex)
+      abort(ex)
     end
 
     # Attempts to unlock the lock. Fails if the lock doesn't exist, or if it is

--- a/spec/unit/mb/chef_mutex_spec.rb
+++ b/spec/unit/mb/chef_mutex_spec.rb
@@ -153,6 +153,12 @@ describe MB::ChefMutex do
         expect { synchronize }.to raise_error(RuntimeError)
       end
 
+      it "does not crash the mutex actor" do
+        expect { chef_mutex.synchronize(&test_block) }.to raise_error(RuntimeError)
+
+        expect { chef_mutex.to_s }.to_not raise_error(Celluloid::DeadActorError)
+      end
+
       context "and passed unlock_on_failure: false" do
         before do
           chef_mutex.stub(unlock_on_failure: false)


### PR DESCRIPTION
The `ChefMutex#synchronize` method will re-raise an exception after cleaning up after itself. This causes [misleading crash messages](https://gist.github.com/reset/142a90d8d23b15f81874) when something goes wrong because a raise crashes the caller and the receiving actor (in this case, the ChefMutex).

We should abort out of synchronize instead.
