### PR TITLE
catch an error case where a node object doesn't exist but a

### DIFF
--- a/motherbrain.gemspec
+++ b/motherbrain.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'net-ssh'
   s.add_runtime_dependency 'net-sftp'
   s.add_runtime_dependency 'solve', '>= 0.4.4'
-  s.add_runtime_dependency 'ridley', '~> 0.12.1'
+  s.add_runtime_dependency 'ridley', '~> 0.12.3'
   s.add_runtime_dependency 'chozo', '~> 0.6.0'
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'thor', '~> 0.18.0'


### PR DESCRIPTION
client does when a partial bootstrap is occuring
