### PR TITLE
environment unlock has supervision crash

### DIFF
--- a/lib/mb/chef_mutex.rb
+++ b/lib/mb/chef_mutex.rb
@@ -166,7 +166,9 @@ module MotherBrain
         job.set_status("Unlocking #{to_s}")
       end
 
-      report(attempt_unlock)
+      attempt_unlock
+
+      report(true)
     end
 
     private

--- a/spec/unit/mb/chef_mutex_spec.rb
+++ b/spec/unit/mb/chef_mutex_spec.rb
@@ -231,6 +231,10 @@ describe MB::ChefMutex do
       unlock
     end
 
+    it "returns true" do
+      expect(unlock).to be_true
+    end
+
     context "when passed a job" do
       let(:options) { { job: job_stub } }
 


### PR DESCRIPTION
Already unlocked: https://gh.riotgames.com/gist/1515
Locked: https://gh.riotgames.com/gist/1516
