### PR TITLE
motherbrain group doesn't use expanded run list

### DIFF
--- a/lib/mb/group.rb
+++ b/lib/mb/group.rb
@@ -54,15 +54,8 @@ module MotherBrain
         "#{attribute_escape(key)}:#{value}"
       end
 
-      items += roles.collect do |role|
-        item = "role[#{role}]"
-        "run_list:#{solr_escape(item)}"
-      end
-
-      items += recipes.collect do |recipe|
-        item = "recipe[#{recipe}]"
-        "run_list:#{solr_escape(item)}"
-      end
+      items += roles.collect { |role| "roles:#{solr_escape(role)}" }
+      items += recipes.collect { |recipe| "recipes:#{solr_escape(recipe)}" }
 
       items.join(' AND ')
     end

--- a/spec/unit/mb/group_spec.rb
+++ b/spec/unit/mb/group_spec.rb
@@ -152,20 +152,23 @@ describe MB::Group do
   end
 
   describe "#search_query" do
+    let(:group) { double('group') }
+    subject { group.search_query(environment) }
+
     context "with one chef attribute" do
-      subject do
+      let(:group) do
         MB::Group.new("db_master") do
           chef_attribute "pvpnet.database.master", true
         end
       end
 
       it "returns one key:value search string" do
-        subject.search_query(environment).should eql("chef_environment:#{environment} AND pvpnet_database_master:true")
+        expect(subject).to eql("chef_environment:#{environment} AND pvpnet_database_master:true")
       end
     end
 
     context "with multiple chef attributes" do
-      subject do
+      let(:group) do
         MB::Group.new("db_master") do
           chef_attribute "pvpnet.database.master", true
           chef_attribute "pvpnet.database.slave", false
@@ -173,12 +176,12 @@ describe MB::Group do
       end
 
       it "returns them escaped and joined together by AND" do
-        subject.search_query(environment).should eql("chef_environment:#{environment} AND pvpnet_database_master:true AND pvpnet_database_slave:false")
+        expect(subject).to eql("chef_environment:#{environment} AND pvpnet_database_master:true AND pvpnet_database_slave:false")
       end
     end
 
     context "with multiple recipes" do
-      subject do
+      let(:group) do
         MB::Group.new("pvpnet") do
           recipe "pvpnet::default"
           recipe "pvpnet::database"
@@ -186,24 +189,24 @@ describe MB::Group do
       end
 
       it "returns them escaped and joined together by AND" do
-        subject.search_query(environment).should eql("chef_environment:#{environment} AND run_list:recipe\\[pvpnet\\:\\:default\\] AND run_list:recipe\\[pvpnet\\:\\:database\\]")
+        expect(subject).to eql("chef_environment:#{environment} AND recipes:pvpnet\\:\\:default AND recipes:pvpnet\\:\\:database")
       end
     end
 
     context "with dash-separated recipes" do
-      subject do
+      let(:group) do
         MB::Group.new("pvpnet") do
           recipe "build-essential"
         end
       end
 
       it "does not escape the dash" do
-        subject.search_query(environment).should eql("chef_environment:#{environment} AND run_list:recipe\\[build-essential\\]")
+        expect(subject).to eql("chef_environment:#{environment} AND recipes:build-essential")
       end
     end
 
     context "with multiple roles" do
-      subject do
+      let(:group) do
         MB::Group.new("roles") do
           role "app_server"
           role "database_server"
@@ -211,7 +214,7 @@ describe MB::Group do
       end
 
       it "returns them escaped and joined together by AND" do
-        subject.search_query(environment).should eql("chef_environment:#{environment} AND run_list:role\\[app_server\\] AND run_list:role\\[database_server\\]")
+        expect(subject).to eql("chef_environment:#{environment} AND roles:app_server AND roles:database_server")
       end
     end
   end


### PR DESCRIPTION
Say I have the following.

recipe database.rb

```
  ....
```

recipe master_database.rb

```
include_recipe "my_app::database"
```

motherbrain.rb

```
group "datatabase" do
  recipe "my_app::database"
end
```

If I run a command on the "database" group, then I expect the command to be ran on all databases, including the master.  Right now, it only runs commands on nodes that have the recipe in their normal run list, not their expanded run list.
