### PR TITLE
enable in process testing for aruba

### DIFF
--- a/bin/mb
+++ b/bin/mb
@@ -2,4 +2,4 @@
 $:.push File.expand_path("../../lib", __FILE__)
 require 'motherbrain'
 
-MB::CliGateway.start
+MB::Cli::Runner.new(ARGV).execute!

--- a/features/cli/configure_command.feature
+++ b/features/cli/configure_command.feature
@@ -3,6 +3,7 @@ Feature: configuring the motherbrain (MB) command line interface (CLI)
   I need a way to configure my MB CLI based on answers I provide to a set of questions
   So it is quick and easy for me to configure or reconfigure my MB CLI
 
+  @spawn
   Scenario: generating a new config file
     Given a motherbrain configuration does not exist
     When I run the "configure" command interactively
@@ -23,6 +24,7 @@ Feature: configuring the motherbrain (MB) command line interface (CLI)
       | ssh.user         | root                                             |
       | ssh.password     | secretpass                                       |
 
+  @spawn
   Scenario: attempting to generate a new config when one already exists
     Given a valid motherbrain configuration
     When I run the "configure" command interactively
@@ -32,6 +34,7 @@ Feature: configuring the motherbrain (MB) command line interface (CLI)
       """
     And the exit status should be the code for error "ConfigExists"
 
+  @spawn
   Scenario: forcefully generating a config when one already exists
     Given a valid motherbrain configuration
     When I run the "configure" command interactively with:

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -9,6 +9,8 @@ require 'motherbrain'
 def setup_env
   require 'rspec'
   require 'aruba/cucumber'
+  require 'aruba/in_process'
+  require 'aruba/spawn_process'
 
   Dir[File.join(File.expand_path("../../../spec/support/**/*.rb", __FILE__))].each { |f| require f }
 
@@ -20,11 +22,22 @@ def setup_env
     end
   end
 
+  Aruba::InProcess.main_class = MB::Cli::Runner
+  Aruba.process               = Aruba::InProcess
+
   World(Aruba::Api)
   World(MotherBrain::SpecHelpers)
 
   Before do
     @config = generate_valid_config
+  end
+
+  Before('@in-process') do
+    Aruba.process = Aruba::InProcess
+  end
+
+  Before('@spawn') do
+    Aruba.process = Aruba::SpawnProcess
   end
 end
 
@@ -43,4 +56,3 @@ else
     World(MB::Mixin::CodedExit)
   end
 end
-

--- a/lib/mb/cli.rb
+++ b/lib/mb/cli.rb
@@ -3,5 +3,48 @@ module MotherBrain
     autoload :Base, 'mb/cli/base'
     autoload :Shell, 'mb/cli/shell'
     autoload :SubCommand, 'mb/cli/sub_command'
+
+    # This is the main entry point for the CLI. It exposes the method {#execute!} to
+    # start the CliGateway.
+    #
+    # @note the arity of {#initialize} and {#execute!} are extremely important for testing purposes. It
+    #   is a requirement to perform in-process testing with Aruba. In process testing is much faster
+    #   than spawning a new Ruby process for each test.
+    class Runner
+      # @param [Array] argv
+      # @param [IO] stdin
+      # @param [IO] stdout
+      # @param [IO] stderr
+      # @param [Kernel] kernel
+      def initialize(argv, stdin = STDIN, stdout = STDOUT, stderr = STDERR, kernel = Kernel)
+        @argv, @stdin, @stdout, @stderr, @kernel = argv, stdin, stdout, stderr, kernel
+      end
+
+      # Start the CLI Gateway
+      def execute!
+        MB::CliGateway.start(@argv)
+      rescue MBError => ex
+        ui.error ex
+        @kernel.exit(ex.exit_code)
+      rescue Ridley::Errors::ConnectionFailed => ex
+        ui.error "[ERROR] Unable to connect to the configured Chef server: #{ex.message}."
+        ui.error "[ERROR] Check your configuration and network settings and try again."
+        @kernel.exit(MB::ChefConnectionError.exit_code)
+      rescue Thor::Error => ex
+        ui.error ex.message
+        @kernel.exit(1)
+      rescue Errno::EPIPE
+        # This happens if a thor command is piped to something like `head`,
+        # which closes the pipe when it's done reading. This will also
+        # mean that if the pipe is closed, further unnecessary
+        # computation will not occur.
+        @kernel.exit(0)
+      end
+
+      # @return [MB::Cli::Shell::Color, MB::Cli::Shell::Basic]
+      def ui
+        @ui ||= MB::Cli::Shell.shell.new
+      end
+    end
   end
 end

--- a/lib/mb/cli_gateway.rb
+++ b/lib/mb/cli_gateway.rb
@@ -142,22 +142,6 @@ module MotherBrain
         end
 
         dispatch(nil, given_args.dup, nil, config)
-      rescue MBError => ex
-        ui.error ex
-        exit_with(ex)
-      rescue Ridley::Errors::ConnectionFailed => ex
-        ui.error "[ERROR] Unable to connect to the configured Chef server: #{ex.message}."
-        ui.error "[ERROR] Check your configuration and network settings and try again."
-        exit_with MB::ChefConnectionError.new
-      rescue Thor::Error => ex
-        ui.error ex.message
-        exit(1)
-      rescue Errno::EPIPE
-        # This happens if a thor command is piped to something like `head`,
-        # which closes the pipe when it's done reading. This will also
-        # mean that if the pipe is closed, further unnecessary
-        # computation will not occur.
-        exit(0)
       ensure
         Celluloid.shutdown
       end


### PR DESCRIPTION
this requires the addition of a Cli wrapper class to instantiate and run the
cli called MB::Cli::Runner. This has an initializer with a special arity and
responds to #execute! to start the CLI
