### PR TITLE
Manifest Files should allow IP ranges

### DIFF
--- a/lib/mb/bootstrap/manifest.rb
+++ b/lib/mb/bootstrap/manifest.rb
@@ -110,11 +110,12 @@ module MotherBrain
       #
       # @return [Array] of hosts
       def hosts_for_group(group)
-        node_groups.select { |node_group|
+        hosts = node_groups.select { |node_group|
           node_group[:groups].include?(group)
         }.collect { |node_group|
           node_group[:hosts]
-        }.flatten
+        }
+        MB::NodeFilter.expand_ipranges(hosts.flatten)
       end
 
       # Validates that the instance of manifest describes a layout for the given routine

--- a/lib/mb/node_filter.rb
+++ b/lib/mb/node_filter.rb
@@ -12,6 +12,20 @@ module MotherBrain
       def filter(segments, nodes)
         new(segments).filter(nodes)
       end
+
+      # Expands any IP address ranges in the given segments and
+      # returns the segments Array with any IP ranges expanded.
+      #
+      # @param  segments [Array<String>] an Array of hostnames or IPs
+      #
+      # @return [Array<String>]
+      def expand_ipranges(segments)
+        node_filter = new(segments)
+        segments.collect do |segment| 
+          range = node_filter.iprange(segment)
+          range.nil? ? segment : range
+        end.flatten
+      end
     end
 
     # @return [Array]

--- a/spec/unit/mb/node_filter_spec.rb
+++ b/spec/unit/mb/node_filter_spec.rb
@@ -14,6 +14,15 @@ describe MB::NodeFilter do
   let(:filtered) { subject.filter(nodes) }
   let(:filter) {[]}
 
+  describe ":expand_iprange" do
+    let(:expand_ipranges) { described_class.expand_ipranges(nodes) }
+    let(:nodes) { ["192.168.0.2", "192.168.0.5-8"] }
+
+    it "expands any ipranges" do
+      expect(expand_ipranges).to eq(["192.168.0.2", "192.168.0.5", "192.168.0.6", "192.168.0.7", "192.168.0.8"])
+    end
+  end
+
   describe "#ipaddress?" do
     it "is true for valid ipaddresses" do
        expect(subject.ipaddress?("192.168.1.1")).to be_true


### PR DESCRIPTION
When bootstrapping large numbers of nodes with very similar IPs it would be much easier to do something along the lines of 10.20.37.15-145 than to have to create a command separated list of all those elements.
