### PR TITLE
Crash in node filtering

### DIFF
--- a/lib/mb/bootstrap/manifest.rb
+++ b/lib/mb/bootstrap/manifest.rb
@@ -112,9 +112,9 @@ module MotherBrain
       def hosts_for_group(group)
         hosts = node_groups.select do |node_group|
           node_group[:groups].include?(group)
-        end.collect { |node_group| node_group[:hosts] }
+        end.collect { |node_group| node_group[:hosts] }.flatten
 
-        MB::NodeFilter.expand_ipranges(hosts.flatten)
+        MB::NodeFilter.expand_ipranges(hosts)
       end
 
       # Validates that the instance of manifest describes a layout for the given routine

--- a/lib/mb/node_filter.rb
+++ b/lib/mb/node_filter.rb
@@ -3,10 +3,9 @@ module MotherBrain
     class << self
       # Filters the given nodes based on the given segments
       #
-      # @param [Array] segments
-      #   an Array of Strings to match nodes on
-      # @param [Array] nodes
-      #   an Array of Ridley::NodeObject
+      # @param [Array<String>] segments
+      #   strings to match nodes on
+      # @param [Array<Ridley::NodeObject>] nodes
       #
       # @return [Array] nodes that matched the segments
       def filter(segments, nodes)
@@ -32,10 +31,10 @@ module MotherBrain
     # @return [Array<String>]
     attr_reader :segments
 
-    # @param [Array<String>] segments
+    # @param [Array<String>, String] segments
     #   an Array of hostnames or IPs
     def initialize(segments)
-      @segments = segments
+      @segments = Array(segments).flatten
     end
 
     # Filters the given array of nodes against the segments
@@ -45,9 +44,7 @@ module MotherBrain
     #
     # @return [Array] nodes that matched
     def filter(nodes)
-      nodes.select do |node|
-        matches?(node)
-      end
+      nodes.select { |node| matches?(node) }
     end
 
     # Checks the node against the instance's segments

--- a/spec/unit/mb/node_filter_spec.rb
+++ b/spec/unit/mb/node_filter_spec.rb
@@ -8,7 +8,20 @@ describe MB::NodeFilter do
         d.stub(:public_ipv4).and_return("192.168.1.#{i}")
       end
     end
-  end  
+  end
+
+  describe "ClassMethods" do
+    describe "::filter" do
+      let(:segments) { [["192.168.1.3-5"]] }
+      subject(:filter) { described_class.filter(segments, nodes) }
+
+      context "given an array of arrays of segments" do
+        it "returns the correct number of nodes" do
+          expect(filter).to have(3).items
+        end
+      end
+    end
+  end
 
   subject { MB::NodeFilter.new(filter) }
   let(:filtered) { subject.filter(nodes) }


### PR DESCRIPTION
```
MotherBrain::CommandInvoker::Worker crashed!
NoMethodError: undefined method `match' for []:Array
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/node_filter.rb:62:in `ipaddress?'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/node_filter.rb:44:in `block in matches?'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/node_filter.rb:43:in `each'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/node_filter.rb:43:in `any?'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/node_filter.rb:43:in `matches?'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/node_filter.rb:32:in `block in filter'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/node_filter.rb:31:in `select'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/node_filter.rb:31:in `filter'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/node_filter.rb:13:in `filter'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command_runner.rb:129:in `on'
    /home/mb_jenkins/.mb/tmp/cbplugin20130710-3033-140zza9/motherbrain.rb:383:in `block (6 levels) in from_path'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command_runner.rb:88:in `instance_eval'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command_runner.rb:88:in `async'
    /home/mb_jenkins/.mb/tmp/cbplugin20130710-3033-140zza9/motherbrain.rb:382:in `block (5 levels) in from_path'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command_runner.rb:55:in `instance_eval'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command_runner.rb:55:in `run'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command_runner.rb:47:in `initialize'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command.rb:70:in `new'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command.rb:70:in `invoke'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/component.rb:101:in `invoke'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command_runner.rb:229:in `invoke'
    /home/mb_jenkins/.mb/tmp/cbplugin20130710-3033-140zza9/motherbrain.rb:412:in `block (3 levels) in from_path'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command_runner.rb:55:in `instance_eval'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command_runner.rb:55:in `run'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command_runner.rb:47:in `initialize'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command.rb:70:in `new'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command.rb:70:in `invoke'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/motherbrain-0.9.0/lib/mb/command_invoker/worker.rb:34:in `run'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/celluloid-0.14.1/lib/celluloid/calls.rb:25:in `public_send'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/celluloid-0.14.1/lib/celluloid/calls.rb:25:in `dispatch'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/celluloid-0.14.1/lib/celluloid/calls.rb:67:in `dispatch'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/celluloid-0.14.1/lib/celluloid/actor.rb:326:in `block in handle_message'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/celluloid-0.14.1/lib/celluloid/tasks.rb:42:in `block in initialize'
    /opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/celluloid-0.14.1/lib/celluloid/tasks/task_fiber.rb:11:in `block in create'
```
