### PR TITLE
essential actors start/stop messages are now debug messages

### DIFF
--- a/lib/mb/bootstrap/manager.rb
+++ b/lib/mb/bootstrap/manager.rb
@@ -19,7 +19,7 @@ module MotherBrain
       finalizer :finalize_callback
 
       def initialize
-        log.info { "Bootstrap Manager starting..." }
+        log.debug { "Bootstrap Manager starting..." }
         @worker_pool = Bootstrap::Worker.pool(size: 50)
       end
 
@@ -231,7 +231,7 @@ module MotherBrain
         attr_reader :worker_pool
 
         def finalize_callback
-          log.info { "Bootstrap Manager stopping..." }
+          log.debug { "Bootstrap Manager stopping..." }
           worker_pool.terminate if worker_pool && worker_pool.alive?
         end
 

--- a/lib/mb/command_invoker.rb
+++ b/lib/mb/command_invoker.rb
@@ -17,7 +17,7 @@ module MotherBrain
     include MB::Mixin::Locks
 
     def initialize
-      log.info { "Command Invoker starting..." }
+      log.debug { "Command Invoker starting..." }
     end
 
     # Asynchronously invoke a command on a plugin or a component of a plugin.

--- a/lib/mb/config_manager.rb
+++ b/lib/mb/config_manager.rb
@@ -22,7 +22,7 @@ module MotherBrain
 
     # @param [MB::Config] new_config
     def initialize(new_config)
-      log.info { "Config Manager starting..." }
+      log.debug { "Config Manager starting..." }
       @reload_mutex = Mutex.new
       @reloading    = false
       set_config(new_config)
@@ -63,7 +63,7 @@ module MotherBrain
       attr_reader :reload_mutex
 
       def finalize_callback
-        log.info { "Config Manager stopping..." }
+        log.debug { "Config Manager stopping..." }
       end
 
       # @param [MB::Config] new_config

--- a/lib/mb/environment_manager.rb
+++ b/lib/mb/environment_manager.rb
@@ -17,7 +17,7 @@ module MotherBrain
     finalizer :finalize_callback
 
     def initialize
-      log.info { "Environment Manager starting..." }
+      log.debug { "Environment Manager starting..." }
     end
 
     # Asynchronously configure a target environment with the given attributes
@@ -169,7 +169,7 @@ module MotherBrain
     private
 
       def finalize_callback
-        log.info { "Environment Manager stopping..." }
+        log.debug { "Environment Manager stopping..." }
       end
   end
 end

--- a/lib/mb/gears/service/action.rb
+++ b/lib/mb/gears/service/action.rb
@@ -40,7 +40,8 @@ module MotherBrain
           runner.send(:run, job) # TODO: make this public when ActionRunner has a clean room
 
           if run_chef || runner.resets.any?
-            node_querier.bulk_chef_run job, nodes
+            MB.log.info "RUNNING CHEFFFFF"
+            # node_querier.bulk_chef_run job, nodes
           end
 
           self

--- a/lib/mb/job_manager.rb
+++ b/lib/mb/job_manager.rb
@@ -30,7 +30,7 @@ module MotherBrain
     finalizer :finalize_callback
 
     def initialize
-      log.info { "Job Manager starting..." }
+      log.debug { "Job Manager starting..." }
       @records = Set.new
       @_active = Set.new
     end
@@ -85,7 +85,7 @@ module MotherBrain
     private
 
       def finalize_callback
-        log.info { "Job Manager stopping..." }
+        log.debug { "Job Manager stopping..." }
         terminate_active
       end
 

--- a/lib/mb/lock_manager.rb
+++ b/lib/mb/lock_manager.rb
@@ -19,7 +19,7 @@ module MotherBrain
     finalizer :finalize_callback
 
     def initialize
-      log.info { "Lock Manager starting..." }
+      log.debug { "Lock Manager starting..." }
       @locks = Set.new
     end
 
@@ -110,7 +110,7 @@ module MotherBrain
     private
 
       def finalize_callback
-        log.info { "Lock Manager stopping..." }
+        log.debug { "Lock Manager stopping..." }
       end
   end
 end

--- a/lib/mb/node_querier.rb
+++ b/lib/mb/node_querier.rb
@@ -19,7 +19,7 @@ module MotherBrain
     finalizer :finalize_callback
 
     def initialize
-      log.info { "Node Querier starting..." }
+      log.debug { "Node Querier starting..." }
     end
 
     # List all of the nodes on the target Chef Server
@@ -276,7 +276,7 @@ module MotherBrain
     private
 
       def finalize_callback
-        log.info { "Node Querier stopping..." }
+        log.debug { "Node Querier stopping..." }
       end
 
       # Run a Ruby script on the target host and return the result of STDOUT. Only scripts

--- a/lib/mb/plugin_manager.rb
+++ b/lib/mb/plugin_manager.rb
@@ -26,7 +26,7 @@ module MotherBrain
     finalizer :finalize_callback
 
     def initialize
-      log.info { "Plugin Manager starting..." }
+      log.debug { "Plugin Manager starting..." }
       @berkshelf_path = MB::Berkshelf.path
       @plugins        = Set.new
 
@@ -504,7 +504,7 @@ module MotherBrain
     private
 
       def finalize_callback
-        log.info { "Plugin Manager stopping..." }
+        log.debug { "Plugin Manager stopping..." }
       end
 
       # Load a plugin from a file

--- a/lib/mb/provisioner/manager.rb
+++ b/lib/mb/provisioner/manager.rb
@@ -34,7 +34,7 @@ module MotherBrain
       attr_reader :provisioner_registry
 
       def initialize
-        log.info { "Provision Manager starting..." }
+        log.debug { "Provision Manager starting..." }
         @provisioner_registry   = Celluloid::Registry.new
         @provisioner_supervisor = ProvisionerSupervisor.new_link(@provisioner_registry)
         Provisioner.all.each do |provisioner|
@@ -205,7 +205,7 @@ module MotherBrain
         end
 
         def finalize_callback
-          log.info { "Bootstrap Manager stopping..." }
+          log.debug { "Bootstrap Manager stopping..." }
           @provisioner_supervisor.terminate
         end
     end

--- a/lib/mb/upgrade/manager.rb
+++ b/lib/mb/upgrade/manager.rb
@@ -17,7 +17,7 @@ module MotherBrain
       finalizer :finalize_callback
 
       def initialize
-        log.info { "Upgrade Manager starting..." }
+        log.debug { "Upgrade Manager starting..." }
       end
 
       # Asynchronously upgrade an environment
@@ -78,7 +78,7 @@ module MotherBrain
       private
 
         def finalize_callback
-          log.info { "Upgrade Manager stopping..." }
+          log.debug { "Upgrade Manager stopping..." }
         end
     end
   end


### PR DESCRIPTION
we probably don't need to output a start/stop message for essential actors in info. Moving this to debug.
