### PR TITLE
make sure sudo config settings are passed in on bootstrap

### DIFF
--- a/lib/mb/bootstrap/manager.rb
+++ b/lib/mb/bootstrap/manager.rb
@@ -81,6 +81,7 @@ module MotherBrain
           environment_attributes: Hash.new,
           hints: Hash.new,
           bootstrap_proxy: Application.config[:chef][:bootstrap_proxy],
+          sudo: Application.config[:ssh][:sudo],
           force: false
         )
         options[:environment] = environment


### PR DESCRIPTION
When trying to bootstrap as an existing user that isn't root but has sudo access, the sudo configuration is not passed in.
