### PR TITLE
Fixes issue 604

### DIFF
--- a/lib/mb/node_filter.rb
+++ b/lib/mb/node_filter.rb
@@ -54,6 +54,7 @@ module MotherBrain
     #
     # @return [Boolean]
     def matches?(node)
+      segments.empty? ||
       segments.any? do |s|
         if ipaddress?(s)
           s == node.public_ipv4


### PR DESCRIPTION
#604

When there are no search segments, the #matches? method returns an empty list. Motherbrain then attempts to run commands on no nodes and explodes.

This short circuits the search when there are no segments, returning the entire list of nodes instead of filtering it down to nothing.
