### PR TITLE
Add an option to force the value of an attribute back

### DIFF
--- a/lib/mb/gears/service/action_runner.rb
+++ b/lib/mb/gears/service/action_runner.rb
@@ -117,7 +117,8 @@ module MotherBrain
                       "Toggling node attribute '#{key}' back to '#{original_value.inspect}' on #{node.name}"
                     end
                     job.set_status(message)
-                    options[:force_value_to].nil? ? node.set_chef_attribute(key, original_value) : node.set_chef_attribute(key, options[:force_value_to])
+                    value_to_set = options[:force_value_to].nil? ? original_value : options[:force_value_to]
+                    node.set_chef_attribute(key, value_to_set)
                     node.save
                   }
                 end

--- a/lib/mb/rest_gateway.rb
+++ b/lib/mb/rest_gateway.rb
@@ -47,7 +47,7 @@ module MotherBrain
     # @option options [Integer] :port (26100)
     # @option options [Boolean] :quiet (false)
     def initialize(options = {})
-      log.info { "REST Gateway starting..." }
+      log.debug { "REST Gateway starting..." }
 
       options = DEFAULT_OPTIONS.merge(options.slice(*VALID_OPTIONS))
       app     = MB::API::Application.new
@@ -63,7 +63,7 @@ module MotherBrain
     private
 
       def finalize_callback
-        log.info { "REST Gateway stopping..." }
+        log.debug { "REST Gateway stopping..." }
         self.shutdown
       end
   end

--- a/spec/unit/mb/gears/service/action_runner_spec.rb
+++ b/spec/unit/mb/gears/service/action_runner_spec.rb
@@ -4,9 +4,16 @@ describe MB::Gear::Service::ActionRunner do
   let(:environment) { "rspec" }
   let(:node_one) { double(name: 'node-one', save: nil) }
   let(:node_two) { double(name: 'node-two', save: nil) }
+  let(:node_three) { Ridley::NodeObject.new(nil) }
+  let(:job) { double(set_status: nil) }
   let(:nodes) { [ node_one, node_two ] }
 
   subject { described_class.new(environment, nodes) }
+
+  before do
+    node_three.stub(:reload)
+    node_three.stub(:save)
+  end
 
   describe "#environment_attribute" do
     let(:key) { "ruby.application.version" }
@@ -27,6 +34,103 @@ describe MB::Gear::Service::ActionRunner do
     it "adds an item to the list of #node_attributes to set" do
       subject.node_attribute(key, value, options)
       expect(subject.send(:node_attributes)).to have(1).item
+    end
+  end
+
+  describe "#set_node_attributes" do
+    let(:nodes) { [ node_three ] }
+
+    let(:set_node_attributes) { subject.send(:set_node_attributes, job) }
+
+    context "when force_value_to and toggle are sent" do
+
+      before do
+        subject.node_attribute('some.attr', 123, toggle: true, force_value_to: 789)
+      end
+
+      it "sets the node attribute" do
+        node_three.should_receive(:set_chef_attribute).with('some.attr', 123)
+        set_node_attributes
+      end
+
+      it "adds a callback" do
+        set_node_attributes
+        expect(subject.toggle_callbacks.size).to eql(1)
+      end
+    end
+  end
+
+  describe "#set_environment_attributes" do
+    let(:environment) { Ridley::EnvironmentObject.new(nil) }
+    let(:ridley) { double( 'foo', environment: environment_resource) }
+    let(:environment_resource) { double(find: environment) }
+    let(:set_environment_attributes) { subject.send(:set_environment_attributes, job) }
+
+    before do
+      subject.environment_attribute('some.env.attr', 123, toggle: true)
+      MB::Application.stub(:[]).and_return(ridley)
+      environment.stub(:save)
+    end
+
+    it "sets the environment attribute" do
+      environment.should_receive(:set_default_attribute).with('some.env.attr', 123)
+      set_environment_attributes
+    end
+
+    it "adds a callback" do
+      set_environment_attributes
+      expect(subject.toggle_callbacks.size).to eql(1)
+    end
+  end
+
+  describe "#reset" do
+    let(:nodes) { [ node_three ] }
+
+    let(:reset) { subject.send(:reset, job) }
+
+    context "when the callback toggles a node attribute" do
+
+      before do
+        subject.node_attribute('some.attr', 123, toggle: true)
+        subject.send(:set_node_attributes, job)
+      end
+
+      it "resets the original value" do
+        node_three.should_receive(:set_chef_attribute).with('some.attr', nil)
+        reset
+      end
+    end
+
+    context "when the callback uses force_value_to on a node attribute" do
+
+      before do
+        subject.node_attribute('some.attr', 123, toggle: true, force_value_to: 789)
+        subject.send(:set_node_attributes, job)
+      end
+
+      it "sets the attribute to the forced value" do
+        node_three.should_receive(:set_chef_attribute).with('some.attr', 789)
+        reset
+      end
+    end
+
+    context "when the callback toggles an environment attribute" do
+      let(:environment) { Ridley::EnvironmentObject.new(nil) }
+      let(:ridley) { double( 'foo', environment: environment_resource) }
+      let(:environment_resource) { double(find: environment) }
+
+
+      before do
+        MB::Application.stub(:[]).and_return(ridley)
+        environment.stub(:save)
+        subject.environment_attribute('some.env.attr', 123, toggle: true)
+        subject.send(:set_environment_attributes, job)
+      end
+
+      it "removes the attribute key" do
+        environment.should_receive(:delete_default_attribute).with('some.env.attr')
+        reset
+      end
     end
   end
 end


### PR DESCRIPTION
:construction: 

We noticed a few nodes ending up in a bad state because of failures or attributes set - toggling would set the value from `true` to `true`, achieving nothing but sadness. 

We should have a new option in the plugin that can set the value back to a defined value, no matter what.
