### PR TITLE
Celluloid logging is noisy

### DIFF
--- a/lib/mb/logging.rb
+++ b/lib/mb/logging.rb
@@ -81,7 +81,7 @@ module MotherBrain
         end
 
         Ridley.logger = @logger
-        Celluloid.logger = @logger
+        Celluloid.logger = ENV["DEBUG_CELLULOID"] ? @logger : nil
 
         @logger
       end


### PR DESCRIPTION
As celluloid moves forward, it seems to be more loud with warnings about
innocuous code. We should silence it unless we really want to hear it.
