### PR TITLE
This worked by coincidence (given that a hash evaluates true), however i...

### DIFF
--- a/lib/mb/cli/sub_command/plugin.rb
+++ b/lib/mb/cli/sub_command/plugin.rb
@@ -157,6 +157,7 @@ module MotherBrain
                     plugin.freeze,
                     environment.freeze,
                     state.freeze,
+                    true,
                     service_options
                   )
 


### PR DESCRIPTION
...t meant that no options were being passed through, as the param for options was being left blank
