### PR TITLE
Use cookbook versions found Berksfile.lock if found. (Issue #665)

### DIFF
--- a/lib/mb/bootstrap/manager.rb
+++ b/lib/mb/bootstrap/manager.rb
@@ -76,7 +76,6 @@ module MotherBrain
       # @see {#async_bootstrap} for options
       def bootstrap(job, environment, manifest, plugin, options = {})
         options = options.reverse_merge(
-          cookbook_versions: Hash.new,
           component_versions: Hash.new,
           environment_attributes: Hash.new,
           hints: Hash.new,
@@ -104,9 +103,10 @@ module MotherBrain
             set_component_versions(environment, plugin, options[:component_versions])
           end
 
-          if options[:cookbook_versions].any?
+          cookbook_versions = options[:cookbook_versions] || plugin.cookbook_versions
+          if cookbook_versions.any?
             job.set_status("Setting cookbook versions")
-            set_cookbook_versions(environment, options[:cookbook_versions])
+            set_cookbook_versions(environment, cookbook_versions)
           end
 
           if options[:environment_attributes].any?

--- a/lib/mb/upgrade/worker.rb
+++ b/lib/mb/upgrade/worker.rb
@@ -104,7 +104,7 @@ module MotherBrain
 
         # @return [Hash]
         def cookbook_versions
-          options[:cookbook_versions] || {}
+          options[:cookbook_versions] || plugin.cookbook_versions
         end
 
         # @return [Hash]

--- a/lib/motherbrain.rb
+++ b/lib/motherbrain.rb
@@ -20,6 +20,7 @@ require 'mb/core_ext'
 require 'mb/grape_ext'
 require 'mb/ridley_ext'
 require 'mb/thor_ext'
+require 'berkshelf'
 
 module MotherBrain
   autoload :API, 'mb/api'

--- a/motherbrain.gemspec
+++ b/motherbrain.gemspec
@@ -55,4 +55,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'buff-platform', '~> 0.1'
   s.add_dependency 'buff-ruby_engine', '~> 0.1'
   s.add_dependency 'grape-swagger', '~> 0.6.0'
+  s.add_dependency 'berkshelf', '~> 3.0.0.beta7'
 end

--- a/spec/fixtures/myface-0.1.0/Berksfile.lock
+++ b/spec/fixtures/myface-0.1.0/Berksfile.lock
@@ -1,0 +1,3 @@
+GRAPH
+  cookbook1 (2.0.1)
+  cookbook2 (1.0.13)

--- a/spec/unit/mb/berkshelf_spec.rb
+++ b/spec/unit/mb/berkshelf_spec.rb
@@ -35,4 +35,21 @@ describe MB::Berkshelf do
       subject.should be_a(Pathname)
     end
   end
+
+  describe MB::Berkshelf::Lockfile do
+    describe "#locked_versions" do
+
+      let(:plugin_path) { '/foo' }
+      subject { MB::Berkshelf::Lockfile.from_path(plugin_path) }
+
+      context "when there is no lockfile present" do
+        its(:locked_versions) { should == {} }
+      end
+
+      context "when there is a lockfile present" do
+        let(:plugin_path) { fixtures_path.join('myface-0.1.0') }
+        its(:locked_versions) { should == {'cookbook1' => '2.0.1', 'cookbook2' => '1.0.13'}}
+      end
+    end
+  end
 end

--- a/spec/unit/mb/bootstrap/manager_spec.rb
+++ b/spec/unit/mb/bootstrap/manager_spec.rb
@@ -8,8 +8,10 @@ describe MB::Bootstrap::Manager do
     MB::CookbookMetadata.from_file(fixtures_path.join('cb_metadata.rb'))
   }
 
+  let(:cookbook_versions) { {} }
+
   let(:plugin) {
-    MB::Plugin.new(cookbook_metadata) do
+    MB::Plugin.new(cookbook_metadata, cookbook_versions) do
       component "activemq" do
         group "master"
         group "slave"
@@ -128,6 +130,15 @@ describe MB::Bootstrap::Manager do
         manager.should_not_receive(:chef_synchronize)
         job.should_receive(:report_failure)
 
+        run
+      end
+    end
+
+    context "when the plugin has cookbook version dependencies set" do
+      let(:cookbook_versions) { {'cookbook1' => '1.2.3', 'cookbook2' => '4.5.6'} }
+
+      it "should set the cookbook versions on the environment" do
+        manager.should_receive(:set_cookbook_versions).with(environment, cookbook_versions)
         run
       end
     end

--- a/spec/unit/mb/plugin_spec.rb
+++ b/spec/unit/mb/plugin_spec.rb
@@ -107,6 +107,10 @@ describe MB::Plugin do
       it "returns a MB::Plugin from the given directory" do
         subject.should be_a(MB::Plugin)
       end
+
+      it "sets the cookbook_versions from the Berksfile.lock" do
+        subject.cookbook_versions.should == {'cookbook1' => '2.0.1', 'cookbook2' => '1.0.13'}
+      end
     end
   end
 

--- a/spec/unit/mb/upgrade/worker_spec.rb
+++ b/spec/unit/mb/upgrade/worker_spec.rb
@@ -15,7 +15,8 @@ describe MB::Upgrade::Worker do
   let(:job) { job_double }
   let(:options) { Hash.new }
   let(:nodes) { %w[node1 node2 node3] }
-  let(:plugin) { double MB::Plugin, name: plugin_name }
+  let(:locked_versions) { {} }
+  let(:plugin) { double MB::Plugin, name: plugin_name, cookbook_versions: locked_versions }
   let(:plugin_name) { "plugin_name" }
 
   before do
@@ -59,6 +60,15 @@ describe MB::Upgrade::Worker do
         job.should_receive(:report_failure)
         run
       end
+    end
+
+    context "when cookbooks are found in the Berksfile.lock" do
+      let(:locked_versions) { {'foo' => '1.2.3', 'bar' => '4.5.6'} }
+      it "updates the cookbook versions from the lockfile" do
+        worker.should_receive(:set_cookbook_versions).with(environment_name, locked_versions)
+        run
+      end
+
     end
 
     context "when only cookbook_versions is passed as an option" do


### PR DESCRIPTION
The plugin is who has knowledge of the root path. During plugin creation look for the Berksfile.lock in the root and if found set an attribute called cookbook_version to a hash of all the locked dependencies. This can then be used by the upgrade/bootstrap manager/worker to use either the cookbook_version passed on the command line or the cookbook versions in the plugin.
- Added Berksfile.locl to myface test fixture
- Added berkshelf as a first class dependency
- Added wrapper around Berkshelf::Lockfile
- Have the plugin try to parse its cookbook dependencies from the Berksfile.lock.
- Hide the --cookbooks option and print a deprecation warning.
- Bootstrap checks cookbook_versions in options first then checks for versions in the plugin.
- Upgrade checks cookbook_versions in options first then checks for versions in the plugin.
