### PR TITLE
Add more aborts to node_querier

### DIFF
--- a/lib/mb/environment_manager.rb
+++ b/lib/mb/environment_manager.rb
@@ -117,14 +117,16 @@ module MotherBrain
       nodes = nodes_for_environment(environment.name)
 
       job.set_status("Examining #{nodes.length} nodes")
+
       nodes.collect do |node|
-        log.debug "About to execute on #{node.public_hostname}"
+        log.debug "About to execute on: \"#{node.public_hostname}\""
         node_querier.future(:execute_command, node.public_hostname, "echo %time%")
       end.each do |future|
         begin
           response = future.value
         rescue RemoteCommandError => error
-          log.warn "Examine command on #{error.host} failed"
+          log.warn "Examine command failed on: \"#{error.host}\""
+          log.warn "  " + error.message
         end
       end
       job.report_success("Completed on #{nodes.length} nodes.")

--- a/lib/mb/node_querier.rb
+++ b/lib/mb/node_querier.rb
@@ -177,6 +177,10 @@ module MotherBrain
         return nil
       end
 
+      unless host.present?
+        abort RemoteCommandError.new("cannot put_secret without a hostname or ipaddress")
+      end
+
       response = chef_connection.node.put_secret(host)
 
       if response.error?
@@ -196,6 +200,11 @@ module MotherBrain
     #
     # @return [Ridley::HostConnection::Response]
     def execute_command(host, command)
+
+      unless host.present?
+        abort RemoteCommandError.new("cannot execute command without a hostname or ipaddress")
+      end
+
       response = chef_connection.node.execute_command(host, command)
 
       if response.error?
@@ -478,6 +487,10 @@ module MotherBrain
       name    = name.split('.rb')[0]
       lines   = File.readlines(MB.scripts.join("#{name}.rb"))
       command_lines = lines.collect { |line| line.gsub('"', "'").strip.chomp }
+
+      unless host.present?
+        abort RemoteCommandError.new("cannot execute a ruby_script without a hostname or ipaddress")
+      end
 
       response = chef_connection.node.ruby_script(host, command_lines)
       


### PR DESCRIPTION
There are still some easy ways to just crash node_querier - especially when you end up passing a blank / nil hostname to methods that aren't `chef_run`.
