### PR TITLE
lock harder on http because of 0.6.0.pre

### DIFF
--- a/motherbrain.gemspec
+++ b/motherbrain.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   # s.add_dependency 'dcell', '~> 0.14.0'
   s.add_dependency 'reel', '~> 0.4.0'
   s.add_dependency 'reel-rack'
+  s.add_dependency 'http', '~> 0.5.0'
   s.add_dependency 'grape', '~> 0.6.0'
   s.add_dependency 'net-ssh'
   s.add_dependency 'net-sftp'


### PR DESCRIPTION
We noticed a fresh box pulled in 0.6.0.pre of the http gem, causing some bad behavior with reel 0.4.0.

It looks like reel 0.4.0 has a dependency on http of `>= 0.5.0` that would cause this behavior. For now, we should limit this dependency until the pre-release gems are released and we want to move up.
