### PR TITLE
Safe node querier

### DIFF
--- a/lib/mb/node_querier.rb
+++ b/lib/mb/node_querier.rb
@@ -364,7 +364,7 @@ module MotherBrain
       
       job.set_status("Host registered as #{node_name}.")
 
-      node = fetch_node(node_name)
+      node = fetch_node(job, node_name)
 
       required_run_list = []
       chef_synchronize(chef_environment: node.chef_environment, force: options[:force], job: job) do
@@ -418,7 +418,7 @@ module MotherBrain
       end
       job.set_status("Host registered as #{node_name}.")
 
-      node = fetch_node(node_name)
+      node = fetch_node(job, node_name)
 
       required_run_list = []
       chef_synchronize(chef_environment: node.chef_environment, force: options[:force], job: job) do
@@ -536,7 +536,7 @@ module MotherBrain
       end.flatten.uniq
     end
 
-    def fetch_node(node_name)
+    def fetch_node(job, node_name)
       node = safe_remote(node_name) { chef_connection.node.find(node_name) }
     rescue RemoteCommandError => e
       job.report_failure("Encountered error retrieving the node object.")


### PR DESCRIPTION
This prevents some crashes in NodeQuerier

When NodeQuerier encounters an unhandled exception, it dies causing the current job to be lost. To the user, this looks like mb is hanging, where it is actually just waiting for more work to do as it's discarded the work it was doing when NodeQuerier crashed.
