### PR TITLE
constrain reel-rack

### DIFF
--- a/motherbrain.gemspec
+++ b/motherbrain.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'celluloid-io', '~> 0.16.pre'
   # s.add_dependency 'dcell', '~> 0.14.0'
   s.add_dependency 'reel', '~> 0.4.0'
-  s.add_dependency 'reel-rack'
+  s.add_dependency 'reel-rack', '~> 0.1.0'
   s.add_dependency 'http', '~> 0.5.0'
   s.add_dependency 'grape', '~> 0.6.0'
   s.add_dependency 'net-ssh'


### PR DESCRIPTION
On a fresh ruby installation.

ERROR:  While executing gem ... (Gem::ImpossibleDependenciesError)
    The user requires motherbrain (= 1.1.2) but it conflicted:
  Activated reel-0.4.0 instead of (>= 0.5.0) via:
    reel-rack-0.2.0, motherbrain-1.1.2
  Activated reel-0.4.0 instead of (>= 0.5.0) via:
    reel-rack-0.2.0, motherbrain-1.1.2
