### PR TITLE
fix rspec-guard syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,6 @@ group :test do
   gem 'guard-cucumber'
   gem 'guard-rspec'
   gem 'guard-spork'
-  gem 'guard-yard'
 
   require 'rbconfig'
 

--- a/Guardfile
+++ b/Guardfile
@@ -1,18 +1,12 @@
 notification :off
 
-guard 'spork' do
+guard :spork do
   watch('Gemfile')
   watch('spec/spec_helper.rb')     { :rspec }
   watch(%r{^spec/support/.+\.rb$}) { :rspec }
 end
 
-guard 'yard', stdout: '/dev/null', stderr: '/dev/null' do
-  watch(%r{app/.+\.rb})
-  watch(%r{lib/.+\.rb})
-  watch(%r{ext/.+\.c})
-end
-
-guard 'rspec', cli: "--color --drb --format Fuubar", all_on_start: false, all_after_pass: false do
+guard :rspec, cmd: "bundle exec rspec --color --drb --format Fuubar", all_on_start: false, all_after_pass: false do
   watch(%r{^spec/unit/.+_spec\.rb$})
   watch(%r{^spec/acceptance/.+_spec\.rb$})
 
@@ -21,7 +15,7 @@ guard 'rspec', cli: "--color --drb --format Fuubar", all_on_start: false, all_af
   watch('spec/spec_helper.rb')        { "spec" }
 end
 
-guard 'cucumber', cli: "--drb --require features --format pretty", all_on_start: false, all_after_pass: false do
+guard :cucumber, cli: "--drb --require features --format pretty", all_on_start: false, all_after_pass: false do
   watch(%r{^features/.+\.feature$})
   watch(%r{^features/support/.+$})                      { 'features' }
   watch(%r{^features/step_definitions/(.+)_steps\.rb$}) { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'features' }


### PR DESCRIPTION
cli was replaced by cmd - it no longer runs specs with bundler, you now need to explicitly tell it to
