### PR TITLE
make connector_for_os public and use it in environment_manager

### DIFF
--- a/lib/mb/environment_manager.rb
+++ b/lib/mb/environment_manager.rb
@@ -81,7 +81,7 @@ module MotherBrain
 
         job.set_status("Performing a chef client run on #{nodes.length} nodes")
         nodes.collect do |node|
-          node_querier.future(:chef_run, node.public_hostname, connector: node.chef_attributes.os)
+          node_querier.future(:chef_run, node.public_hostname, connector: node_querier.connector_for_os(node.chef_attributes.os))
         end.each do |future|
           begin
             response = future.value

--- a/lib/mb/node_querier.rb
+++ b/lib/mb/node_querier.rb
@@ -477,12 +477,6 @@ module MotherBrain
       job.terminate if job && job.alive?
     end
 
-    private
-
-    def finalize_callback
-      log.debug { "Node Querier stopping..." }
-    end
-
     # Returns a String representing the best connector
     # type to use when communicating with a given node
     #
@@ -499,6 +493,12 @@ module MotherBrain
       else
         nil
       end
+    end
+
+    private
+
+    def finalize_callback
+      log.debug { "Node Querier stopping..." }
     end
 
     # Run a Ruby script on the target host and return the result of STDOUT. Only scripts

--- a/spec/unit/mb/node_querier_spec.rb
+++ b/spec/unit/mb/node_querier_spec.rb
@@ -529,4 +529,32 @@ describe MB::NodeQuerier do
       end
     end
   end
+
+  describe "#connector_for_os" do
+    let(:connector_for_os) { subject.connector_for_os(os) }
+
+    context "when the os is windows" do
+      let(:os) { "windows" }
+
+      it "returns winrm" do
+        expect(connector_for_os).to eql("winrm")
+      end
+    end
+
+    context "when the os is linux" do
+      let(:os) { "linux" }
+
+      it "returns ssh" do
+        expect(connector_for_os).to eql("ssh")
+      end
+    end
+
+    context "when the os is not windows or linux" do
+      let(:os) { "solaris" }
+
+      it "returns nil" do
+        expect(connector_for_os).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Missed a case where the unparsed OS was making it to ridley-connectors. Aslo fixed by / Related to https://github.com/RiotGames/ridley-connectors/pull/25
