### PR TITLE
ensure abort() is passed an Exception

### DIFF
--- a/lib/mb/chef_mutex.rb
+++ b/lib/mb/chef_mutex.rb
@@ -150,13 +150,14 @@ module MotherBrain
 
       unlock
     rescue => ex
-      ex = ex.respond_to?(:cause) ? ex.cause : ex
+      cause = ex.respond_to?(:cause) ? ex.cause : ex
+      cause ||= ex
 
-      unless ex.is_a?(ResourceLocked)
+      unless cause.is_a?(ResourceLocked)
         unlock if unlock_on_failure
       end
 
-      abort(ex)
+      abort(cause)
     end
 
     # Attempts to unlock the lock. Fails if the lock doesn't exist, or if it is


### PR DESCRIPTION
Apparently, Exception#cause does nothing to ensure that there is actually an
inner or original Exception instance, and this leads to an unhelpful error
message about expecting String and getting Nil when rescue in
`ChefMutex#synchronize()` finally calls `abort()`.

In my case, the error I needed was that the constraints in the environment 
were untenable because I hadn't run `berks upload`.

I tried to write a spec for this, but wasn't able to assert that the mutex 
should receive abort and that the argument should be a RuntimeError with 
message 'foo'. It would either barf on me for having an error, hang, or never
receive any calls to abort.
