### PR TITLE
Modest update to thor version dependency.

### DIFF
--- a/motherbrain.gemspec
+++ b/motherbrain.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'net-sftp'
   s.add_dependency 'solve', '~> 1.1'
   s.add_dependency 'ridley-connectors', '~> 2.2'
-  s.add_dependency 'thor', '~> 0.18.0'
+  s.add_dependency 'thor', '~> 0.19'
   s.add_dependency 'faraday', '~> 0.9'
   s.add_dependency 'multi_json'
   s.add_dependency 'fog', '~> 1.10.0'


### PR DESCRIPTION
Meant to get around this:

ERROR:  While executing gem ... (Gem::DependencyError)
    Unable to resolve dependencies: motherbrain requires thor (~> 0.18.0); berkshelf requires thor (~> 0.19)